### PR TITLE
Oracle 11g performance issue with dba_free_space. 40 tablespaces. bef…

### DIFF
--- a/etc/zbxdb_checks/oracle/primary.11.cfg
+++ b/etc/zbxdb_checks/oracle/primary.11.cfg
@@ -385,9 +385,14 @@ p_ts: SELECT   'p_ts['||d.name||','||tablespace_name||','||
                     from dba_tablespaces t, dba_data_files f
                    where t.CONTENTS = 'PERMANENT' and f.tablespace_name = t.tablespace_name
                 group by t.tablespace_name) t1,
-               (  select f.tablespace_name, sum (f.bytes) file_free_space
-                    from dba_free_space f
-                group by tablespace_name) t2
+-- Oracle 11-12 perfomance issue with dba_free_space
+--               (  select f.tablespace_name, sum (f.bytes) file_free_space
+--                    from dba_free_space f
+--                group by tablespace_name) t2
+               (  select a.tablespace_name, sum (a.bytes) file_free_space
+                    FROM   SYS.dba_data_files b, SYS.dba_free_space a
+                    WHERE a.tablespace_name = b.tablespace_name
+                    GROUP BY a.tablespace_name, b.tablespace_name) t2
          where t1.tablespace_name = t2.tablespace_name(+)
        )
   cross JOIN   ( SELECT LEVEL k FROM dual CONNECT BY LEVEL <= 5 ) k


### PR DESCRIPTION
Oracle 11g performance issue with dba_free_space. 40 tablespaces. 
before:00:01:04.83. 
after:00:00:00.25